### PR TITLE
Tela de splash criada

### DIFF
--- a/Codigo/lib/main.dart
+++ b/Codigo/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:patrimonio_mobile/views/home_view.dart';
+import 'package:patrimonio_mobile/views/splash_view.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,7 +24,7 @@ class MyApp extends StatelessWidget {
       supportedLocales: [
         Locale('pt', 'BR'),
       ],
-      home: HomeView(),
+      home: SplashView(),
     );
   }
 }

--- a/Codigo/lib/views/splash_view.dart
+++ b/Codigo/lib/views/splash_view.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'home_view.dart'; // Import correto da sua Home
+import '../services/database_helper.dart'; // Import do seu helper de banco
+
+class SplashView extends StatefulWidget {
+  const SplashView({super.key});
+
+  @override
+  State<SplashView> createState() => _SplashViewState();
+}
+
+class _SplashViewState extends State<SplashView> {
+  @override
+  void initState() {
+    super.initState();
+    _inicializarApp();
+  }
+
+  Future<void> _inicializarApp() async {
+
+    final tempoMinimo = Future.delayed(const Duration(milliseconds: 800));
+
+    final carregarBanco = DatabaseHelper.instance.database;
+
+    await Future.wait([tempoMinimo, carregarBanco]);
+
+    if (mounted) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const HomeView()),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Color(0xFFF1F4F8),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.inventory_2, size: 80, color: Colors.blue),
+            SizedBox(height: 20),
+            Text(
+              "Patrimônio Mobile",
+              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: Colors.blueGrey),
+            ),
+            SizedBox(height: 10),
+            SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2, color: Colors.blue),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Adição de uma tela de transição (SplashView) para melhorar a experiência de inicialização do app e garantir que os recursos essenciais (Banco de Dados) estejam prontos antes do acesso à tela principal.

O que mudou?
Feature: Criação da SplashView com identidade visual do projeto.

Refactor: Substituição do delay estático por lógica assíncrona (Future.wait) que aguarda o carregamento real do DatabaseHelper.

Navigation: Atualização do fluxo de entrada para iniciar na Splash e redirecionar para a HomeView.

UX: Garantia de um tempo mínimo de exibição (800ms) para evitar transições bruscas (efeito "flicker").